### PR TITLE
Raise SystemExit for error

### DIFF
--- a/eval_accuracy.py
+++ b/eval_accuracy.py
@@ -46,7 +46,9 @@ def main(args):
             output = net.build_arch_baseline(batch_x,
                                              is_train=False, num_classes=num_classes)
         else:
-            raise "Please select model from 'caps' or 'cnn_baseline' as the secondary argument of eval.py!"
+            raise SystemExit(
+                "Please select model from 'caps' or 'cnn_baseline' as the "
+                "secondary argument of eval.py!")
         batch_acc = net.test_accuracy(output, batch_labels)
         saver = tf.train.Saver()
 


### PR DESCRIPTION
This causes the system to exit with error code 1 and message.

Replaces code that Python balks at (can't raise a string as an
exception).